### PR TITLE
fix: Don't subscribe until authentication is complete

### DIFF
--- a/src/NetworkLayer.ts
+++ b/src/NetworkLayer.ts
@@ -56,14 +56,12 @@ export default class NetworkLayer {
     this.socket.on('connect', () => {
       if (token) {
         this.emitTransient('authenticate', token, () => {
-          console.log('[AAA] authenticate complated');
           this.authenticated = true;
           this.subscriptions.forEach((subscription, id) => {
             this.subscribe(id, subscription);
           });
         });
       }
-
     });
 
     this.socket.on('subscription update', ({ id, ...payload }: any) => {
@@ -115,7 +113,6 @@ export default class NetworkLayer {
 
       this.subscriptions.set(id, subscription);
 
-      console.log(`[AAA] subscribeFn called when authenticated=${this.authenticated}`);
       if (this.authenticated) {
         this.subscribe(id, subscription);
       }

--- a/src/NetworkLayer.ts
+++ b/src/NetworkLayer.ts
@@ -64,6 +64,10 @@ export default class NetworkLayer {
       }
     });
 
+    this.socket.on('disconnect', () => {
+      this.authenticated = false;
+    });
+
     this.socket.on('subscription update', ({ id, ...payload }: any) => {
       const subscription = this.subscriptions.get(id);
       if (!subscription) {


### PR DESCRIPTION
In some cases, the subscription is established but not yet authenticated, and when the server tries to emit values they may include null sections if those required fetches.

See https://app.asana.com/0/1108647999040215/1143221153894122